### PR TITLE
Allow null, int and float set values and convert them to a string

### DIFF
--- a/src/NoSQLite/Store.php
+++ b/src/NoSQLite/Store.php
@@ -124,8 +124,12 @@ class Store implements \Iterator, \Countable
             throw new \InvalidArgumentException('Expected string as key');
         }
 
-        if (!is_string($value)) {
-            throw new \InvalidArgumentException('Expected string as value');
+        if (!(is_string($value) || is_null($value) || is_scalar($value)) || is_bool($value)) {
+            throw new \InvalidArgumentException('Value type ['.gettype($value).'] not allowed');
+        }
+
+        if($value !== null){
+          $value = strval($value);
         }
 
         $queryString = 'REPLACE INTO ' . $this->name . ' VALUES (:key, :value);';

--- a/test/NoSQLite/Tests/StoreTest.php
+++ b/test/NoSQLite/Tests/StoreTest.php
@@ -184,6 +184,9 @@ class StoreTest extends \PHPUnit_Framework_TestCase
         return array(
             array('key', 'value'),
             array('0', 'value'),
+            array('1', 1234),
+            array('2', 12.34),
+            array('3', null),
         );
     }
 
@@ -195,7 +198,10 @@ class StoreTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(0, 'value'),
-            array('key', 1),
+            array('key', array()),
+            array('foo', false),
+            array('bar', (object) array()),
+            array('foobar', function(){}),
         );
     }
 


### PR DESCRIPTION
Small addition that allows `integers` and `floats` as set value and converts it to `string` using the `strval()` function.